### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -100,7 +100,7 @@ jobs:
       # this will publish to the actor (person) github packages
       - name: Publish to GitHub
         if: github.event_name == 'push'
-        uses: elgohr/Publish-Docker-Github-Action@2.18
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           BRANCH: ${{ env.GITHUB_BRANCH }}
           VERSION: ${{ env.CLOWDER_VERSION }}
@@ -118,7 +118,7 @@ jobs:
       # this will publish to the clowder dockerhub repo
       - name: Publish to Docker Hub
         if: github.event_name == 'push' && github.repository == env.MASTER_REPO
-        uses: elgohr/Publish-Docker-Github-Action@2.18
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           BRANCH: ${{ env.GITHUB_BRANCH }}
           VERSION: ${{ env.CLOWDER_VERSION }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore